### PR TITLE
Feat/policy admin

### DIFF
--- a/src/common/auth/auth.guard.ts
+++ b/src/common/auth/auth.guard.ts
@@ -1,20 +1,15 @@
 import { JwtService } from '@nestjs/jwt';
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { Reflector } from '@nestjs/core';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private jwtService: JwtService, private reflector: Reflector) {}
+  constructor(private jwtService: JwtService) {}
   canActivate(context: ExecutionContext): boolean {
     const ctx = GqlExecutionContext.create(context);
     const { req, res } = ctx.getContext();
     if (!req.cookies.token) {
       return false;
-    }
-    const roles = this.reflector.get<string[]>('role', context.getHandler());
-    if (!roles) {
-      return true;
     }
     const { token } = req.cookies;
     const isVerified = this.jwtService.verify(token, {
@@ -27,10 +22,7 @@ export class AuthGuard implements CanActivate {
         secure: true,
         path: '/',
       });
-      return false;
     }
-    const hasHole = roles.some(() => roles.includes(isVerified.role));
-
-    return !!isVerified && hasHole;
+    return !!isVerified;
   }
 }

--- a/src/common/auth/auth.guard.ts
+++ b/src/common/auth/auth.guard.ts
@@ -1,15 +1,20 @@
 import { JwtService } from '@nestjs/jwt';
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { Reflector } from '@nestjs/core';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private jwtService: JwtService) {}
+  constructor(private jwtService: JwtService, private reflector: Reflector) {}
   canActivate(context: ExecutionContext): boolean {
     const ctx = GqlExecutionContext.create(context);
     const { req, res } = ctx.getContext();
     if (!req.cookies.token) {
       return false;
+    }
+    const roles = this.reflector.get<string[]>('role', context.getHandler());
+    if (!roles) {
+      return true;
     }
     const { token } = req.cookies;
     const isVerified = this.jwtService.verify(token, {
@@ -22,7 +27,10 @@ export class AuthGuard implements CanActivate {
         secure: true,
         path: '/',
       });
+      return false;
     }
-    return !!isVerified;
+    const hasHole = roles.some(() => roles.includes(isVerified.role));
+
+    return !!isVerified && hasHole;
   }
 }

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Role = (...role: string[]) => SetMetadata('role', role);

--- a/src/common/roles/role.guard.ts
+++ b/src/common/roles/role.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(private reflector: Reflector, private jwtService: JwtService) {}
+  canActivate(context: ExecutionContext): boolean {
+    const ctx = GqlExecutionContext.create(context);
+    const { req } = ctx.getContext();
+    const roles = this.reflector.get<string[]>('role', context.getHandler());
+    if (!roles) {
+      return true;
+    }
+    const { token } = req.cookies;
+    const user = this.jwtService.verify(token, {
+      secret: process.env.SECRET,
+    });
+    const role = user.role;
+    const hasHole = roles.some(() => roles.includes(role));
+    return hasHole;
+  }
+}

--- a/src/common/roles/role.module.ts
+++ b/src/common/roles/role.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { RoleGuard } from './role.guard';
+import { Reflector } from '@nestjs/core';
+
+@Module({
+  imports: [],
+  providers: [RoleGuard, Reflector, JwtModule],
+})
+export class RoleModule {}

--- a/src/modules/user/types.ts
+++ b/src/modules/user/types.ts
@@ -13,3 +13,9 @@ export enum Skill {
   ProductDesign = 'Product Design',
   QA = 'QA',
 }
+
+export enum Roles {
+  Admin = 'ADMIN',
+  User = 'USER',
+  Mentor = 'MENTOR',
+}


### PR DESCRIPTION
### Mudanças e adições
- Adiciona proteção as rotas por roles.
- Adiciona o decorator Role()
- Adiciona enum Roles.
- Adiciona RoleGuard.

### Usando o decorator
### Exemplo
```
  @UseGuards(AuthGuard, RoleGuard) // <--- Adicione o RoleGuard ao UseGuard
  @Role(Roles.USER) // <--- Você pode adicionar as roles que estarão permitidas
  @Query(() => User, { name: 'me' })
  async me(@Context('req') req: Request) {
    const token = req.cookies['token'];
    return this.userService.me(token);
  }
```
- Você pode adicionar uma ou mais roles permitidas para a rota.
- Caso a rota não necessite de permissões a adição do decorator Role() não é necessária.