### PR TITLE
Feat/add user languages

### DIFF
--- a/prisma/migrations/20230707192544_add_language_field_in_user_model/migration.sql
+++ b/prisma/migrations/20230707192544_add_language_field_in_user_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "language" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   facebookId          String?         @map("facebook_id")
   githubId            String?         @map("github_id")
   birthDate           DateTime?       @map("birth_date")
+  language            Json?
   country             String?
   state               String?
   city                String?
@@ -44,16 +45,16 @@ model User {
   events              EventsOnUsers[]
   temporaryCodes      TemporaryCode[]
 
-  createdAt           DateTime        @default(now()) @map("created_at")
-  updatedAt           DateTime        @updatedAt @map("updated_at")
-  Event               Event?          @relation(fields: [eventId], references: [id])
-  eventId             String?
-  notificationsData   NotificationData[]
-  notifications       Notification[]
+  createdAt         DateTime           @default(now()) @map("created_at")
+  updatedAt         DateTime           @updatedAt @map("updated_at")
+  Event             Event?             @relation(fields: [eventId], references: [id])
+  eventId           String?
+  notificationsData NotificationData[]
+  notifications     Notification[]
 
-  writtenTestimonies  Testimony[]     @relation("WrittenTestimonies")
-  testimonies         Testimony[]     @relation("Testimonies")
-       
+  writtenTestimonies Testimony[] @relation("WrittenTestimonies")
+  testimonies        Testimony[] @relation("Testimonies")
+
   @@map("users")
 }
 
@@ -128,17 +129,17 @@ model NotificationData {
   notifications Notification[]
 
   @@map("notifications_data")
-} 
+}
 
 model Testimony {
-  id        String    @id @default(uuid())
+  id        String   @id @default(uuid())
   learnerId String
   mentorId  String
   text      String
-  learner   User      @relation("WrittenTestimonies", fields: [learnerId], references: [id])
-  mentor    User      @relation("Testimonies", fields: [mentorId], references: [id])
-  createdAt DateTime  @default(now()) @map("created_at")
-  updatedAt DateTime  @updatedAt @map("updated_at")
+  learner   User     @relation("WrittenTestimonies", fields: [learnerId], references: [id])
+  mentor    User     @relation("Testimonies", fields: [mentorId], references: [id])
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("testimonies")
 }

--- a/schema.gql
+++ b/schema.gql
@@ -37,6 +37,11 @@ type Notification {
   data: NotificationData!
 }
 
+type Language {
+  name: String!
+  proficiency: String!
+}
+
 type User {
   id: ID!
   email: String!
@@ -67,6 +72,7 @@ type User {
   description: String
   isMentor: Boolean
   status: String
+  language: [Language!]
   availability: [Availability!]
   notifications: [Notification!]
 }
@@ -104,24 +110,6 @@ type Skill {
   name: String!
 }
 
-type NotificationData {
-  id: ID!
-  title: String!
-  description: String!
-  imageUrl: String
-  notifierId: ID
-  updatedAt: DateTime!
-  createdAt: DateTime!
-}
-
-type Notification {
-  id: ID!
-  notificationDataId: ID!
-  userId: ID!
-  read: Boolean!
-  data: NotificationData!
-}
-
 type Testimony {
   id: ID!
   mentorId: String!
@@ -150,10 +138,7 @@ type Query {
   skill(id: Int!): Skill!
   findNotifications(userId: String): [Notification!]!
   findOneNotification(id: String!): Notification
-  findTestimonies(
-    learnerId: String
-    mentorId: String
-  ): [CreateTestimonyOutput!]!
+  findTestimonies(learnerId: String, mentorId: String): [CreateTestimonyOutput!]!
   findOneTestimony(id: String!): [CreateTestimonyOutput!]!
 }
 
@@ -195,9 +180,7 @@ type Mutation {
   resetUserPassword(userInput: ResetPasswordInput!): Boolean!
   sendResetPassword(email: String!): Boolean!
   createAvailability(createAvailabilityInput: CreateAvailabilityInput!): User!
-  updateAvailability(
-    updateAvailabilityInput: UpdateAvailabilityInput!
-  ): Availability!
+  updateAvailability(updateAvailabilityInput: UpdateAvailabilityInput!): Availability!
   removeAvailability(id: Int!): Availability!
   createEvent(createEventInput: CreateEventInput!): Event!
   updateEvent(updateEventInput: UpdateEventInput!): Event!
@@ -205,12 +188,8 @@ type Mutation {
   createSkill(createSkillInput: CreateSkillInput!): Skill!
   updateSkill(updateSkillInput: UpdateSkillInput!): Skill!
   removeSkill(id: Int!): Skill!
-  createNotification(
-    createNotificationInput: CreateNotificationInput!
-  ): NotificationData!
-  updateNotification(
-    updateNotificationInput: UpdateNotificationInput!
-  ): NotificationData!
+  createNotification(createNotificationInput: CreateNotificationInput!): NotificationData!
+  updateNotification(updateNotificationInput: UpdateNotificationInput!): NotificationData!
   markRead(id: String!): Notification!
   removeNotification(id: ID!): Boolean!
   createTestimony(createTestimonyInput: CreateTestimonyInput!): Testimony!
@@ -241,6 +220,12 @@ input CreateUserInput {
   facebookId: String
   googleId: String
   status: String
+  language: [CreateLanguageInput!]
+}
+
+input CreateLanguageInput {
+  name: String!
+  proficiency: String!
 }
 
 input UpdateUserDto {
@@ -266,6 +251,7 @@ input UpdateUserDto {
   facebookId: String
   googleId: String
   status: String
+  language: [CreateLanguageInput!]
   id: String!
 }
 
@@ -280,9 +266,7 @@ input SignInUserInput {
   rememberMe: Boolean
 }
 
-"""
-The `Upload` scalar type represents a file upload.
-"""
+"""The `Upload` scalar type represents a file upload."""
 scalar Upload
 
 input ResetPasswordInput {
@@ -330,16 +314,12 @@ input UpdateEventInput {
 }
 
 input CreateSkillInput {
-  """
-  Example field (placeholder)
-  """
+  """Example field (placeholder)"""
   exampleField: Int!
 }
 
 input UpdateSkillInput {
-  """
-  Example field (placeholder)
-  """
+  """Example field (placeholder)"""
   exampleField: Int
   id: Int!
 }

--- a/src/modules/language/dto/create-language.input.ts
+++ b/src/modules/language/dto/create-language.input.ts
@@ -1,0 +1,9 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class CreateLanguageInput {
+  @Field(() => String)
+  name: string;
+  @Field(() => String)
+  proficiency: string;
+}

--- a/src/modules/language/dto/update-language.input.ts
+++ b/src/modules/language/dto/update-language.input.ts
@@ -1,0 +1,5 @@
+import { InputType, PartialType } from '@nestjs/graphql';
+import { CreateLanguageInput } from './create-language.input';
+
+@InputType()
+export class UpdateLanguageInput extends PartialType(CreateLanguageInput) {}

--- a/src/modules/language/entities/language.entity.ts
+++ b/src/modules/language/entities/language.entity.ts
@@ -1,0 +1,9 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+
+@ObjectType()
+export class Language {
+  @Field(() => String)
+  name: string;
+  @Field(() => String)
+  proficiency: string;
+}

--- a/src/modules/language/language.module.ts
+++ b/src/modules/language/language.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class LanguageModule {}

--- a/src/modules/language/types.ts
+++ b/src/modules/language/types.ts
@@ -1,0 +1,4 @@
+export type Language = {
+  name: string;
+  proficiency: string;
+};

--- a/src/modules/user/dto/create-user.input.ts
+++ b/src/modules/user/dto/create-user.input.ts
@@ -12,6 +12,8 @@ import {
 } from 'class-validator';
 import { createStringRequirements } from '@common/utils';
 import { Skill } from '../types';
+import { Language } from '@modules/language/types';
+import { CreateLanguageInput } from '@modules/language/dto/create-language.input';
 
 @InputType('CreateUserInput')
 export class CreateUserInput {
@@ -131,4 +133,8 @@ export class CreateUserInput {
   @IsString()
   @IsOptional()
   status?: string;
+
+  @Field(() => [CreateLanguageInput], { nullable: true })
+  @IsOptional()
+  language?: Language[];
 }

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -2,6 +2,7 @@ import { Availability } from './../../availability/entities/availability.entity'
 import { Directive, Field, Float, ObjectType } from '@nestjs/graphql';
 import { FieldId } from '@common/decorators';
 import { Notification } from '@modules/notifications/entities/notification.entity';
+import { Language } from '@modules/language/entities/language.entity';
 
 @ObjectType()
 @Directive('@key(fields: "id")')
@@ -64,6 +65,8 @@ export class User {
   isMentor?: boolean;
   @Field({ nullable: true })
   status?: string;
+  @Field(() => [Language], { nullable: true })
+  language?: Language[];
   @Field(() => [Availability], { nullable: true })
   availability?: Availability[];
   @Field(() => [Notification], { nullable: true })


### PR DESCRIPTION
### Adiciona idiomas que o usuário fala no cadastro de conta

Exemplo:

```
"language": [
  {
    "name": "Inglês",
    "proficiency": "Beginner"
  },
  {
    "name": "Português - Br",
    "proficiency": "Native"
  }
]
```